### PR TITLE
Update maven-bundle-plugin version

### DIFF
--- a/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -57,7 +57,7 @@
         <dependency.pentaho-metaverse-api>${kettleVersion}</dependency.pentaho-metaverse-api>
         <!-- Plugin dependencies -->
         <target.jdk.version>1.7</target.jdk.version>
-        <plugin.maven-bundle-plugin.version>2.3.7</plugin.maven-bundle-plugin.version>
+        <plugin.maven-bundle-plugin.version>2.5.3</plugin.maven-bundle-plugin.version>
         <plugin.maven-compiler-plugin.version>3.1</plugin.maven-compiler-plugin.version>
         <mockito.version>1.9.5</mockito.version>
         <junit.version>4.4</junit.version>
@@ -106,7 +106,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>2.5.3</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
Version 2.3.7 of maven-bundle-plugin is throwing an exception when building the resulting project.