### PR TITLE
[BACKLOG-16259] Update parent pom version

### DIFF
--- a/pentaho-ce-bundle-archetype/README.md
+++ b/pentaho-ce-bundle-archetype/README.md
@@ -9,7 +9,7 @@ The pentaho-ce-bundle-archetype can be used as a basis for any project (or even 
 $ mvn archetype:generate                               \
      -DarchetypeGroupId=org.pentaho                    \
      -DarchetypeArtifactId=pentaho-ce-bundle-archetype \
-     -DarchetypeVersion=1.0.18                          \
+     -DarchetypeVersion=8.1.0.0-SNAPSHOT                \
      -DgroupId=org.pentaho                             \
      -DartifactId=my-pentaho-project                   \
      -Dversion=1.0-SNAPSHOT                          \

--- a/pentaho-ce-bundle-archetype/pom.xml
+++ b/pentaho-ce-bundle-archetype/pom.xml
@@ -1,15 +1,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.pentaho</groupId>
   <artifactId>pentaho-ce-bundle-archetype</artifactId>
-  <version>1.0.19-SNAPSHOT</version>
+  <version>8.1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.pentaho</groupId>
-    <artifactId>pentaho-ce-jar-parent-pom</artifactId>
-    <version>RELEASE</version>
+    <artifactId>maven-project-archetypes</artifactId>
+    <version>8.1.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Pentaho Community Edition Bundle Project Archetype</name>
@@ -40,12 +39,13 @@
     <tag>HEAD</tag>
   </scm>
 
-  <properties>
-    <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
-    <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-  </properties>
-
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pentaho-ce-bundle-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/pentaho-ce-bundle-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,8 +5,7 @@
   <parent>
     <groupId>org.pentaho</groupId>
     <artifactId>pentaho-ce-bundle-parent-pom</artifactId>
-    <!-- specific versions set upon migration to maintenance -->
-    <version>RELEASE</version>
+    <version>${project.version}</version>
   </parent>
 
   <groupId>${groupId}</groupId>

--- a/pentaho-ce-jar-archetype/pom.xml
+++ b/pentaho-ce-jar-archetype/pom.xml
@@ -1,15 +1,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.pentaho</groupId>
   <artifactId>pentaho-ce-jar-archetype</artifactId>
-  <version>1.0.25-SNAPSHOT</version>
+  <version>8.1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.pentaho</groupId>
-    <artifactId>pentaho-ce-jar-parent-pom</artifactId>
-    <version>RELEASE</version>
+    <artifactId>maven-project-archetypes</artifactId>
+    <version>8.1.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Pentaho Community Edition Java Project Archetype</name>
@@ -40,12 +39,13 @@
     <tag>HEAD</tag>
   </scm>
 
-  <properties>
-    <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
-    <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-  </properties>
-
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pentaho-ce-jar-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/pentaho-ce-jar-archetype/src/main/resources/archetype-resources/pom.xml
@@ -10,8 +10,7 @@
   <parent>
     <groupId>org.pentaho</groupId>
     <artifactId>pentaho-ce-jar-parent-pom</artifactId>
-    <!-- specific versions set upon migration to maintenance -->
-    <version>RELEASE</version>
+    <version>${project.version}</version>
   </parent>
 
   <name>Pentaho Community Edition Project: ${artifactId}</name>

--- a/pentaho-hadoop-shim-archetype/cdh/pom.xml
+++ b/pentaho-hadoop-shim-archetype/cdh/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.pentaho.hadoop.shim</groupId>
     <artifactId>hadoop-shim-archetype-ce</artifactId>
-    <version>1.20</version>
+    <version>8.1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdh-archetype</artifactId>
-  <version>1.20-SNAPSHOT</version>
+  <version>8.1.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>Pentaho Community Edition CDH Shim Java Project Archetype</name>

--- a/pentaho-hadoop-shim-archetype/emr/pom.xml
+++ b/pentaho-hadoop-shim-archetype/emr/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.pentaho.hadoop.shim</groupId>
     <artifactId>hadoop-shim-archetype-ce</artifactId>
-    <version>1.20</version>
+    <version>8.1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>emr-archetype</artifactId>
-  <version>1.20-SNAPSHOT</version>
+  <version>8.1.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>Pentaho Community Edition EMR Shim Java Project Archetype</name>

--- a/pentaho-hadoop-shim-archetype/hdi/pom.xml
+++ b/pentaho-hadoop-shim-archetype/hdi/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.pentaho.hadoop.shim</groupId>
     <artifactId>hadoop-shim-archetype-ce</artifactId>
-    <version>1.20</version>
+    <version>8.1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hdi-archetype</artifactId>
-  <version>1.20-SNAPSHOT</version>
+  <version>8.1.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>Pentaho Community Edition HDI Shim Java Project Archetype</name>

--- a/pentaho-hadoop-shim-archetype/hdp/pom.xml
+++ b/pentaho-hadoop-shim-archetype/hdp/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.pentaho.hadoop.shim</groupId>
     <artifactId>hadoop-shim-archetype-ce</artifactId>
-    <version>1.20</version>
+    <version>8.1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hdp-archetype</artifactId>
-  <version>1.20-SNAPSHOT</version>
+  <version>8.1.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>Pentaho Community Edition HDP Shim Java Project Archetype</name>

--- a/pentaho-hadoop-shim-archetype/mapr/pom.xml
+++ b/pentaho-hadoop-shim-archetype/mapr/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.pentaho.hadoop.shim</groupId>
     <artifactId>hadoop-shim-archetype-ce</artifactId>
-    <version>1.20</version>
+    <version>8.1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>mapr-archetype</artifactId>
-  <version>1.20-SNAPSHOT</version>
+  <version>8.1.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>Pentaho Community Edition MapR Shim Java Project Archetype</name>

--- a/pentaho-hadoop-shim-archetype/pom.xml
+++ b/pentaho-hadoop-shim-archetype/pom.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.pentaho</groupId>
-    <artifactId>pentaho-ce-jar-parent-pom</artifactId>
-    <version>RELEASE</version>
+    <artifactId>maven-project-archetypes</artifactId>
+    <version>8.1.0.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.pentaho.hadoop.shim</groupId>
   <artifactId>hadoop-shim-archetype-ce</artifactId>
-  <version>1.21-SNAPSHOT</version>
+  <version>8.1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
@@ -41,6 +41,14 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <modules>
+    <module>cdh</module>
+    <module>emr</module>
+    <module>hdi</module>
+    <module>hdp</module>
+    <module>mapr</module>
+  </modules>
 
   <build>
     <extensions>

--- a/pentaho-pdi-job-plugin-archetype/pom.xml
+++ b/pentaho-pdi-job-plugin-archetype/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.pentaho</groupId>
   <artifactId>pdi-job-plugin-archetype</artifactId>
-  <version>2.21-SNAPSHOT</version>
+  <version>8.1.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <parent>
     <groupId>org.pentaho</groupId>
-    <artifactId>pentaho-ce-jar-parent-pom</artifactId>
-    <version>RELEASE</version>
+    <artifactId>maven-project-archetypes</artifactId>
+    <version>8.1.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Pentaho Community Edition Java Project Archetype</name>
@@ -21,11 +20,18 @@
   </scm>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
     <extensions>
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>2.4</version>
+        <version>${archetype-packaging.version}</version>
       </extension>
     </extensions>
 
@@ -33,18 +39,13 @@
       <plugins>
         <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>2.4</version>
+          <version>${maven-archetype-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
   </build>
 
   <description>pdi-job-plugin OSGi bundle project.</description>
-
-  <properties>
-    <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
-    <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-  </properties>
 
   <licenses>
     <license>

--- a/pentaho-pdi-job-plugin-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/pentaho-pdi-job-plugin-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -3,13 +3,13 @@
     xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <requiredProperties>
-    <requiredProperty key="plugin_class_name"></requiredProperty>
-    <requiredProperty key="plugin_name"></requiredProperty>
-    <requiredProperty key="plugin_category"></requiredProperty>
-    <requiredProperty key="plugin_description"></requiredProperty>
     <requiredProperty key="kettleVersion">
       <defaultValue>7.0.0.3-62</defaultValue>
-    </requiredProperty>    
+    </requiredProperty>
+    <requiredProperty key="plugin_class_name" />
+    <requiredProperty key="plugin_name" />
+    <requiredProperty key="plugin_category" />
+    <requiredProperty key="plugin_description" />
   </requiredProperties>
   <fileSets>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -24,7 +24,7 @@
     <parent>
     	<groupId>org.pentaho</groupId>
     	<artifactId>pentaho-ce-bundle-parent-pom</artifactId>
-    	<version>RELEASE</version>
+    	<version>${project.version}</version>
   	</parent>
 
     <groupId>${groupId}</groupId>

--- a/pentaho-pdi-step-plugin-archetype/pom.xml
+++ b/pentaho-pdi-step-plugin-archetype/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.pentaho</groupId>
   <artifactId>pdi-step-plugin-archetype</artifactId>
-  <version>2.21-SNAPSHOT</version>
+  <version>8.1.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <parent>
     <groupId>org.pentaho</groupId>
-    <artifactId>pentaho-ce-jar-parent-pom</artifactId>
-    <version>RELEASE</version>
+    <artifactId>maven-project-archetypes</artifactId>
+    <version>8.1.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Pentaho Community Edition Java Project Archetype</name>
@@ -21,11 +20,18 @@
   </scm>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
     <extensions>
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>2.4</version>
+        <version>${archetype-packaging.version}</version>
       </extension>
     </extensions>
 
@@ -33,18 +39,13 @@
       <plugins>
         <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>2.4</version>
+          <version>${maven-archetype-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
   </build>
 
   <description>pdi-step-plugin OSGi bundle project.</description>
-
-  <properties>
-    <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
-    <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-  </properties>
 
   <licenses>
     <license>

--- a/pentaho-pdi-step-plugin-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/pentaho-pdi-step-plugin-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -3,13 +3,13 @@
     xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <requiredProperties>
-    <requiredProperty key="plugin_class_name"></requiredProperty>
-    <requiredProperty key="plugin_name"></requiredProperty>
-    <requiredProperty key="plugin_category"></requiredProperty>
-    <requiredProperty key="plugin_description"></requiredProperty>
     <requiredProperty key="kettleVersion">
       <defaultValue>7.0.0.3-62</defaultValue>
     </requiredProperty>
+    <requiredProperty key="plugin_class_name" />
+    <requiredProperty key="plugin_name" />
+    <requiredProperty key="plugin_category" />
+    <requiredProperty key="plugin_description" />
   </requiredProperties>
   <fileSets>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -24,7 +24,7 @@
     <parent>
     	<groupId>org.pentaho</groupId>
     	<artifactId>pentaho-ce-bundle-parent-pom</artifactId>
-    	<version>RELEASE</version>
+    	<version>${project.version}</version>
   	</parent>
 
     <groupId>${groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.pentaho</groupId>
+    <artifactId>pentaho-ce-jar-parent-pom</artifactId>
+    <version>8.1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>maven-project-archetypes</artifactId>
+  <version>8.1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <developers>
+    <developer>
+      <name>Pentaho BDC Team</name>
+      <email>bdconform.pentaho@hitachivantara.com</email>
+      <roles>
+        <role>creator</role>
+        <role>maintainer</role>
+      </roles>
+    </developer>
+  </developers>
+
+  <scm>
+    <developerConnection>scm:git:git@github.com:pentaho/maven-project-archetypes.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <properties>
+    <archetype-packaging.version>2.4</archetype-packaging.version>
+    <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
+    <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
+    <maven-archetype-plugin.version>2.4</maven-archetype-plugin.version>
+  </properties>
+
+  <modules>
+    <module>pentaho-ce-bundle-archetype</module>
+    <module>pentaho-ce-jar-archetype</module>
+    <module>pentaho-hadoop-shim-archetype</module>
+    <module>pentaho-pdi-job-plugin-archetype</module>
+    <module>pentaho-pdi-step-plugin-archetype</module>
+  </modules>
+</project>


### PR DESCRIPTION
@pentaho/x-wing 

- Added new parent pom at root
- There is now a `parentVersion` that can be passed in that allows
the maven-parent-pom version to be set when the archetype is generated