### PR TITLE
[PPP-4936] - upgrading the vulnerable component guava version to 32.1.2-jre

### DIFF
--- a/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -76,7 +76,6 @@
         <plugin.maven-compiler-plugin.version>3.1</plugin.maven-compiler-plugin.version>
         <mockito.version>1.9.5</mockito.version>
         <junit.version>4.4</junit.version>
-        <guava.version>17.0</guava.version>
     </properties>
 
     <dependencies>

--- a/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -76,7 +76,6 @@
         <plugin.maven-compiler-plugin.version>3.1</plugin.maven-compiler-plugin.version>
         <mockito.version>1.9.5</mockito.version>
         <junit.version>4.4</junit.version>
-        <guava.version>17.0</guava.version>
     </properties>
 
     <dependencies>

--- a/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -56,7 +56,6 @@
     <plugin.maven-compiler-plugin.version>3.1</plugin.maven-compiler-plugin.version>
     <mockito.version>1.9.5</mockito.version>
     <junit.version>4.4</junit.version>
-    <guava.version>17.0</guava.version>
     </properties>
 
   <dependencies>

--- a/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -72,7 +72,6 @@
     <target.jdk.version>1.8</target.jdk.version>
     <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
     <junit.version>4.12</junit.version>
-    <guava.version>17.0</guava.version>
     <mockito-all.version>1.9.5</mockito-all.version>
   </properties>
 


### PR DESCRIPTION
[PPP-4936] - upgrading the vulnerable component guava version to 32.1.2-jre

[PPP-4936]: https://hv-eng.atlassian.net/browse/PPP-4936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ