### PR TITLE
[BACKLOG-42521] remove oss license html attachments

### DIFF
--- a/pentaho-ce-bundle-archetype/src/main/resources/archetype-resources/src/main/java/MyService.java
+++ b/pentaho-ce-bundle-archetype/src/main/resources/archetype-resources/src/main/java/MyService.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 package ${package};
 
 public interface MyService {

--- a/pentaho-ce-bundle-archetype/src/main/resources/archetype-resources/src/main/java/MyServiceImpl.java
+++ b/pentaho-ce-bundle-archetype/src/main/resources/archetype-resources/src/main/java/MyServiceImpl.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 package ${package};
 
 import org.slf4j.Logger;

--- a/pentaho-ce-bundle-archetype/src/main/resources/archetype-resources/src/test/java/MyServiceImplTest.java
+++ b/pentaho-ce-bundle-archetype/src/main/resources/archetype-resources/src/test/java/MyServiceImplTest.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 package ${package};
 
 import static org.junit.Assert.*;

--- a/pentaho-ce-jar-archetype/src/main/resources/archetype-resources/src/main/java/MyClass.java
+++ b/pentaho-ce-jar-archetype/src/main/resources/archetype-resources/src/main/java/MyClass.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 package ${package};
 
 import org.slf4j.Logger;

--- a/pentaho-ce-jar-archetype/src/main/resources/archetype-resources/src/test/java/MyClassTest.java
+++ b/pentaho-ce-jar-archetype/src/main/resources/archetype-resources/src/test/java/MyClassTest.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 package ${package};
 
 import static org.junit.Assert.*;

--- a/pentaho-hadoop-shim-archetype/cdh/src/main/resources/archetype-resources/impl/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/pentaho-hadoop-shim-archetype/cdh/src/main/resources/archetype-resources/impl/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/cdh/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/HadoopShim.java
+++ b/pentaho-hadoop-shim-archetype/cdh/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/HadoopShim.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/cdh/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/authorization/ShimNoOpHadoopAuthorizationService.java
+++ b/pentaho-hadoop-shim-archetype/cdh/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/authorization/ShimNoOpHadoopAuthorizationService.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/emr/src/main/resources/archetype-resources/impl/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/pentaho-hadoop-shim-archetype/emr/src/main/resources/archetype-resources/impl/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/emr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/HadoopShim.java
+++ b/pentaho-hadoop-shim-archetype/emr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/HadoopShim.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/emr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/authorization/ShimNoOpHadoopAuthorizationService.java
+++ b/pentaho-hadoop-shim-archetype/emr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/authorization/ShimNoOpHadoopAuthorizationService.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/hdi/src/main/resources/archetype-resources/impl/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/pentaho-hadoop-shim-archetype/hdi/src/main/resources/archetype-resources/impl/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/hdi/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/HadoopShim.java
+++ b/pentaho-hadoop-shim-archetype/hdi/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/HadoopShim.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/hdi/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/authorization/ShimNoOpHadoopAuthorizationService.java
+++ b/pentaho-hadoop-shim-archetype/hdi/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/authorization/ShimNoOpHadoopAuthorizationService.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/hdi/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/invocationhandler/HDIDriverInvocationHandler.java
+++ b/pentaho-hadoop-shim-archetype/hdi/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/invocationhandler/HDIDriverInvocationHandler.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/hdp/src/main/resources/archetype-resources/impl/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/pentaho-hadoop-shim-archetype/hdp/src/main/resources/archetype-resources/impl/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/hdp/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/HadoopShim.java
+++ b/pentaho-hadoop-shim-archetype/hdp/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/HadoopShim.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/hdp/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/authorization/ShimNoOpHadoopAuthorizationService.java
+++ b/pentaho-hadoop-shim-archetype/hdp/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/authorization/ShimNoOpHadoopAuthorizationService.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/ConfigurationProxyV2.java
+++ b/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/ConfigurationProxyV2.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/HadoopShim.java
+++ b/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/HadoopShim.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/MapR5DistributedCacheUtilImpl.java
+++ b/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/MapR5DistributedCacheUtilImpl.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/authorization/ShimNoOpHadoopAuthorizationService.java
+++ b/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/main/java/org/pentaho/hadoop/shim/__shimName__/authorization/ShimNoOpHadoopAuthorizationService.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/test/java/org/pentaho/hadoop/shim/__shimName__/MapR5DistributedCacheUtilImplOSDependentTest.java
+++ b/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/impl/src/test/java/org/pentaho/hadoop/shim/__shimName__/MapR5DistributedCacheUtilImplOSDependentTest.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/LICENSE.txt
+++ b/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/LICENSE.txt
@@ -1,4 +1,4 @@
-Pentaho Developer Edition 10.3 Copyright 2024 Hitachi Vantara, LLC; licensed under the Business Source License 1.1 (BSL). 
+Pentaho Community Edition 10.3 Copyright 2024 Hitachi Vantara, LLC; licensed under the Business Source License 1.1 (BSL). 
 This project may include third party components that are individually licensed per the terms indicated by their respective copyright owners
 included in text file or in the source code. 
 
@@ -10,7 +10,7 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             Hitachi Vantara, LLC.
-Licensed Work:        Pentaho Developer Edition 10.3. The Licensed Work is (c) 2024
+Licensed Work:        Pentaho Community Edition 10.3. The Licensed Work is (c) 2024
                       Hitachi Vantara, LLC.
 Additional Use Grant: None
 Change Date:          Four years from the date the Licensed Work is published.

--- a/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/src/main/java/Messages.java
+++ b/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/src/main/java/Messages.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__.java
+++ b/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Entry.java
+++ b/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Entry.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__EntryAnalyzer.java
+++ b/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__EntryAnalyzer.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__EntryDialog.java
+++ b/pentaho-pdi-job-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__EntryDialog.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/LICENSE.txt
+++ b/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/LICENSE.txt
@@ -1,4 +1,4 @@
-Pentaho Developer Edition 10.3 Copyright 2024 Hitachi Vantara, LLC; licensed under the Business Source License 1.1 (BSL). 
+Pentaho Community Edition 10.3 Copyright 2024 Hitachi Vantara, LLC; licensed under the Business Source License 1.1 (BSL). 
 This project may include third party components that are individually licensed per the terms indicated by their respective copyright owners
 included in text file or in the source code. 
 
@@ -10,7 +10,7 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             Hitachi Vantara, LLC.
-Licensed Work:        Pentaho Developer Edition 10.3. The Licensed Work is (c) 2024
+Licensed Work:        Pentaho Community Edition 10.3. The Licensed Work is (c) 2024
                       Hitachi Vantara, LLC.
 Additional Use Grant: None
 Change Date:          Four years from the date the Licensed Work is published.

--- a/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__.java
+++ b/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Data.java
+++ b/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Data.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Dialog.java
+++ b/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Dialog.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Meta.java
+++ b/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Meta.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__StepAnalyzer.java
+++ b/pentaho-pdi-osgi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__StepAnalyzer.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/LICENSE.txt
+++ b/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/LICENSE.txt
@@ -1,4 +1,4 @@
-Pentaho Developer Edition 10.3 Copyright 2024 Hitachi Vantara, LLC; licensed under the Business Source License 1.1 (BSL). 
+Pentaho Community Edition 10.3 Copyright 2024 Hitachi Vantara, LLC; licensed under the Business Source License 1.1 (BSL). 
 This project may include third party components that are individually licensed per the terms indicated by their respective copyright owners
 included in text file or in the source code. 
 
@@ -10,7 +10,7 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             Hitachi Vantara, LLC.
-Licensed Work:        Pentaho Developer Edition 10.3. The Licensed Work is (c) 2024
+Licensed Work:        Pentaho Community Edition 10.3. The Licensed Work is (c) 2024
                       Hitachi Vantara, LLC.
 Additional Use Grant: None
 Change Date:          Four years from the date the Licensed Work is published.

--- a/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__.java
+++ b/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Data.java
+++ b/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Data.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Dialog.java
+++ b/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Dialog.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Meta.java
+++ b/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Meta.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__StepAnalyzer.java
+++ b/pentaho-pdi-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__StepAnalyzer.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__.java
+++ b/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Data.java
+++ b/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Data.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Dialog.java
+++ b/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Dialog.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Meta.java
+++ b/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Meta.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Source.java
+++ b/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/main/java/__plugin_class_name__Source.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/test/java/__plugin_class_name__Test.java
+++ b/pentaho-streaming-step-plugin-archetype/src/main/resources/archetype-resources/src/test/java/__plugin_class_name__Test.java
@@ -1,14 +1,3 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2028-08-13
- ******************************************************************************/
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )


### PR DESCRIPTION
[DEVO-10639] remove oss license html attachments

(cherry picked from commit fe0a8c266d019483a5fa06c0496927ff236aeea0)

[DEVO-10639]: https://hv-eng.atlassian.net/browse/DEVO-10639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ