### PR TITLE
fix[PPP-6483]: Remove Flexjson from maven-project-archetypes

### DIFF
--- a/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/pmr/pom.xml
+++ b/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/pmr/pom.xml
@@ -91,17 +91,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>net.sf.flexjson</groupId>
-      <artifactId>flexjson</artifactId>
-      <version>${symbol_dollar}{net.sf.flexjson}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/pmr/src/assembly/assembly.xml
+++ b/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/pmr/src/assembly/assembly.xml
@@ -21,7 +21,6 @@
         <include>org.apache.hbase:hbase-hadoop-compat</include>
         <include>org.apache.hbase:hbase-protocol</include>
         <include>org.apache.hbase:hbase-server</include>
-        <include>net.sf.flexjson:flexjson</include>
       </includes>
       <excludes>
         <exclude>*:tests:*</exclude>

--- a/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/pom.xml
+++ b/pentaho-hadoop-shim-archetype/mapr/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,6 @@
         <org.apache.avro.version>1.8.0</org.apache.avro.version>
         <!-- pmr folder -->
         <htrace-core.version>3.1.0-incubating</htrace-core.version>
-        <net.sf.flexjson>2.1</net.sf.flexjson>
         <org.apache.hbase.version>1.1.8-mapr-1710</org.apache.hbase.version>
         <zookeeper.version>3.4.5-mapr-1710</zookeeper.version>
         <!--impl and hbase-comparators folders-->


### PR DESCRIPTION
## Summary

- Dependency: flexjson
- Target version: removal
- Change type: dependency removal

## Validation

- Base branch: master
- Maven build: passed

## Notes

- Removed net.sf.flexjson property from pentaho-hadoop-shim-archetype archetype-resources/pom.xml
- Removed Flexjson dependency from archetype-resources/pmr/pom.xml